### PR TITLE
Fix consistency for `KrausSuperGate` left and right `Gate`s

### DIFF
--- a/hybridq/dm/gate/gate.py
+++ b/hybridq/dm/gate/gate.py
@@ -145,14 +145,19 @@ def KrausSuperGate(gates: {iter[Gate], tuple[iter[Gate], iter[Gate]]},
     tags: dict[any, any], optional
         Dictionary of tags.
     copy: bool, optional
-        A copy of `s` is used instead of a reference if `copy` is True
-        (default: True).
+        A copy of `gates` and `s` is used instead of a reference if `copy` is
+        `True` (default: True).
 
     Returns
     -------
     KrausSuperGate
     """
     from hybridq.gate import TupleGate
+
+    # Copy if needed
+    def _copy(x: iter[any, ...]):
+        from copy import deepcopy
+        return (deepcopy(y) for y in x) if copy else x
 
     def __print_qubits__(self):
         return {
@@ -169,15 +174,15 @@ def KrausSuperGate(gates: {iter[Gate], tuple[iter[Gate], iter[Gate]]},
     try:
         # Try by first assuming that 'gates' is a tuple of gates ...
         l_gates, r_gates = gates
-        l_gates = TupleGate(l_gates)
-        r_gates = TupleGate(g.conj() for g in r_gates)
+        l_gates = TupleGate(_copy(l_gates))
+        r_gates = TupleGate(_copy(r_gates))
 
     # ... if an error occurs ...
     except:
         try:
             # ... try as a single tuple of gates.
-            l_gates = TupleGate(gates)
-            r_gates = TupleGate(g.conj() for g in l_gates)
+            l_gates = TupleGate(_copy(gates))
+            r_gates = _copy(l_gates)
 
         except:
             # Finally, raise an error.
@@ -198,6 +203,7 @@ def KrausSuperGate(gates: {iter[Gate], tuple[iter[Gate], iter[Gate]]},
                      __print__=__print_qubits__),
         gates=(l_gates, r_gates),
         s=(np.array if copy else np.asarray)(s),
+        _conj_rgates=True,
         name='KRAUS')(tags=tags)
 
 

--- a/hybridq/gate/gate.py
+++ b/hybridq/gate/gate.py
@@ -726,7 +726,7 @@ def SchmidtGate(gates: {iter[Gate], tuple[iter[Gate], iter[Gate]]},
         Correlation matrix between `Gates`. More precisely,
         `SchmidtGate.Matrix` is built as follows:
         ```
-        U = \sum_{ij} s_ij G_i G_j.
+        U = \sum_{ij} s_ij L_i R_j.
         ```
         `s` can be a single scalar, a vector or a matrix consistent with the
         number of gates.

--- a/hybridq/gate/property.py
+++ b/hybridq/gate/property.py
@@ -825,8 +825,9 @@ def _s_transform(s):
         raise NotImplementedError
 
 
-@compare('gates,s')
-@staticvars('gates,s',
+@compare('gates,s,_conj_rgates')
+@staticvars('gates,s,_conj_rgates',
+            _conj_rgates=False,
             transform=dict(gates=_gate_transform, s=_s_transform),
             check=dict(s=(lambda s: s is None or 0 <= s.ndim <= 2,
                           "'s' cannot have more than two dimensions.")))
@@ -897,7 +898,8 @@ class SchmidtGate(__Base__):
         l_gates = TupleGate(
             MatrixGate(U=g.matrix(), qubits=g.qubits) for g in l_gates)
         r_gates = TupleGate(
-            MatrixGate(U=g.matrix(), qubits=g.qubits) for g in r_gates)
+            MatrixGate(U=(g.conj() if self._conj_rgates else g).matrix(),
+                       qubits=g.qubits) for g in r_gates)
 
         # Get left and right qubits
         l_qubits, r_qubits = l_gates.qubits, r_gates.qubits

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class MyInstall(DistutilsInstall):
 here = path.abspath(path.dirname(__file__))
 
 # Version
-version = '0.7.7-3'
+version = '0.7.7-4'
 
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
At the moment, right gates in the `KrausSuperGate` are stored already conjugates. This creates some inconsistency while comparing gates from different `KrausSuperGate`s. 

To fix this, `SchmidtGate` allows an extra flag (`_conj_rgates`) to conjugate right `Gate`s while computing `Matrix`, hence allowing the storing of right `Gate`s in `KrausSuperGate` in a consistent way.