### PR TITLE
Fix Docs Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ greatly simplifying the development of new hybrid algorithms and techniques.
 
 ## Documentation
 
-For technical documentation on how to use **HybridQ**, see [hybridq/docs](hybridq/docs).
+For technical documentation on how to use **HybridQ**, see [hybridq/docs](https://github.com/nasa/hybridq/tree/main/docs).
 
 ## Installation
 


### PR DESCRIPTION
The link to docs didn't work for me. This tiny fix should fix it for end users.