### PR TITLE
Noise Utilities

### DIFF
--- a/.github/workflows/python-pytest_noise_1.yml
+++ b/.github/workflows/python-pytest_noise_1.yml
@@ -1,0 +1,28 @@
+name: Python PyTest - noise_1
+
+on:
+  push:
+    branches: [ main, devel ]
+  pull_request:
+    branches: [ main, devel ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull baseline for HybridQ
+        run: |
+          docker pull smandra/hybridq-baseline:latest
+          docker tag smandra/hybridq-baseline:latest hybridq-baseline:latest
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build HybridQ container
+        run: |
+          docker-compose build --build-arg ARCH=x86-64 hybridq
+
+      - name: Run tests
+        run: |
+          docker run --rm hybridq -c 'pip install pytest-random-order && \
+            pytest -sv --random-order -k 'noise_1__' /opt/hybridq/tests/tests.py'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __*__
 __*__.ipynb
 *.so
 *.x
+.DS_Store
+.idea
 dask-worker-space/
 build/
 dist/

--- a/hybridq/noise/channel/__init__.py
+++ b/hybridq/noise/channel/__init__.py
@@ -20,4 +20,5 @@ from hybridq.noise.channel.channel import MatrixChannel, \
                                           GlobalPauliChannel, \
                                           LocalDepolarizingChannel, \
                                           GlobalDepolarizingChannel, \
-                                          AmplitudeDampingChannel
+                                          AmplitudeDampingChannel, \
+                                          LocalDephasingChannel

--- a/hybridq/noise/channel/__init__.py
+++ b/hybridq/noise/channel/__init__.py
@@ -17,4 +17,6 @@ specific language governing permissions and limitations under the License.
 
 from hybridq.noise.channel.channel import MatrixChannel, \
                                           LocalPauliChannel, \
-                                          GlobalPauliChannel
+                                          GlobalPauliChannel, \
+                                          LocalDepolarizingChannel, \
+                                          GlobalDepolarizingChannel

--- a/hybridq/noise/channel/__init__.py
+++ b/hybridq/noise/channel/__init__.py
@@ -19,4 +19,5 @@ from hybridq.noise.channel.channel import MatrixChannel, \
                                           LocalPauliChannel, \
                                           GlobalPauliChannel, \
                                           LocalDepolarizingChannel, \
-                                          GlobalDepolarizingChannel
+                                          GlobalDepolarizingChannel, \
+                                          AmplitudeDampingChannel

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -478,7 +478,7 @@ def LocalPauliChannel(qubits: tuple[any, ...],
         If `copy == True`, then `s` is copied instead of passed by reference
         (default: `True`).
     atol: float, optional
-        Use `atol` as absolute tollerance while checking.
+        Use `atol` as absolute tolerance while checking.
     """
 
     return tuple(
@@ -518,7 +518,7 @@ def LocalDepolarizingChannel(qubits: tuple[any, ...],
     name: str, optional
         Alternative name for channel.
     atol: float, optional
-        Use `atol` as absolute tollerance while checking.
+        Use `atol` as absolute tolerance while checking.
     """
 
     if isinstance(p, float):
@@ -541,3 +541,37 @@ def LocalDepolarizingChannel(qubits: tuple[any, ...],
         GlobalPauliChannel(
             qubits=(q,), name=name, s=s_p(p[q]), tags=tags, atol=atol)
         for q in qubits)
+
+
+def GlobalDepolarizingChannel(qubits: tuple[any, ...],
+                      p: float,
+                      tags: dict[any, any] = None,
+                      name: str = 'GLOBAL_DEPOLARIZING_CHANNEL',
+                      atol: float = 1e-8) -> tuple[GlobalPauliChannel, ...]:
+    """
+    Return a depolarizing channel that acts on all qubits
+
+        rho -> E(rho) = (1-p) rho + p * I/d
+
+    with `rho` being a density matrix of `len(qubits)` qubits,
+    p the user specified depolarizing probability,
+    I the identity matrix, and d=2**len(qubits) the full dimension.
+
+    Parameters
+    ----------
+    qubits: tuple[any, ...]
+        Qubits the `LocalPauliChannel`s will act on.
+    p: float
+        Depolarizing probability.
+    tags: dict[any, any]
+        Tags to add to `LocalPauliChannel`s.
+    name: str, optional
+        Alternative name for channel.
+    atol: float, optional
+        Use `atol` as absolute tolerance while checking.
+    """
+    nq = len(qubits)
+    pi = p / 4**nq
+    s = [pi if i > 0 else 1 - p + pi for i in range(4**nq)]
+
+    return GlobalPauliChannel(qubits=qubits, name=name, s=s, tags=tags, atol=atol)

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -490,9 +490,10 @@ def LocalPauliChannel(qubits: tuple[any, ...],
 def LocalDepolarizingChannel(qubits: tuple[any, ...],
                       p: {float, array, dict},
                       name: str = 'LOCAL_DEPOLARIZING_CHANNEL',
-                      **kwargs) -> tuple[LocalPauliChannel, ...]:
+                      **kwargs) -> tuple[LocalDepolarizingChannel, ...]:
     """
-    Return a `tuple` of depolarizing channels acting independently on `qubits`.
+    Return a `tuple` of `LocalDepolarizingChannel`s acting independently
+    on `qubits`.
     More precisely, each channel has the form:
 
         rho -> E_i(rho) = (1-p_i) rho + p_i * I/2
@@ -564,7 +565,7 @@ def AmplitudeDampingChannel(qubits: tuple[any, ...],
                             atol: float = 1e-8,
                             **kwargs) -> tuple[AmplitudeDampingChannel, ...]:
     """
-    Return a `tuple` of AmplitudeDampingChannel acting independently
+    Return a `tuple` of `AmplitudeDampingChannel`s acting independently
     on `qubits`. There are 4 Kraus operators (for each qubit):
     sqrt(p) * [ [1, 0], [0, sqrt(1-gamma)] ]
     sqrt(p) * [ [0, sqrt(gamma)], [0, 0] ]
@@ -598,7 +599,7 @@ def AmplitudeDampingChannel(qubits: tuple[any, ...],
     gamma = _convert_to_dict(qubits, gamma)
     p = _convert_to_dict(qubits, p)
 
-    def kraus(gamma_i, pi):
+    def adc_kraus(gamma_i, pi):
         E0 = np.sqrt(pi) * np.diag([1, np.sqrt(1-gamma_i)])
         E1 = np.sqrt(pi) * np.array([[0, np.sqrt(gamma_i)], [0, 0]])
         E2 = np.sqrt(1 - pi) * np.diag([np.sqrt(1-gamma_i), 1])
@@ -611,15 +612,16 @@ def AmplitudeDampingChannel(qubits: tuple[any, ...],
                 mats += [m]
         return tuple(mats)
 
-    return tuple(MatrixChannel(LMatrices=kraus(gamma[q], p[q]),
+    return tuple(MatrixChannel(LMatrices=adc_kraus(gamma[q], p[q]),
                          qubits=(q,),
                          s=1,
+                         name=name,
                          atol=atol,
                          **kwargs) for q in qubits)
 
 
 def _convert_to_dict(qubits, arg):
-    if isinstance(arg, float):
+    if isinstance(arg, (float, int)):
         arg = {q: arg for q in qubits}
     elif isinstance(arg, dict):
         pass

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -545,9 +545,8 @@ def LocalDepolarizingChannel(qubits: tuple[any, ...],
 
 def GlobalDepolarizingChannel(qubits: tuple[any, ...],
                       p: float,
-                      tags: dict[any, any] = None,
                       name: str = 'GLOBAL_DEPOLARIZING_CHANNEL',
-                      atol: float = 1e-8) -> tuple[GlobalPauliChannel, ...]:
+                      **kwargs) -> tuple[GlobalPauliChannel, ...]:
     """
     Return a depolarizing channel that acts on all qubits
 
@@ -563,15 +562,12 @@ def GlobalDepolarizingChannel(qubits: tuple[any, ...],
         Qubits the `LocalPauliChannel`s will act on.
     p: float
         Depolarizing probability.
-    tags: dict[any, any]
-        Tags to add to `LocalPauliChannel`s.
     name: str, optional
         Alternative name for channel.
-    atol: float, optional
-        Use `atol` as absolute tolerance while checking.
+    kwargs: kwargs for GlobalPauliChannel
     """
     nq = len(qubits)
     pi = p / 4**nq
     s = [pi if i > 0 else 1 - p + pi for i in range(4**nq)]
 
-    return GlobalPauliChannel(qubits=qubits, name=name, s=s, tags=tags, atol=atol)
+    return GlobalPauliChannel(qubits=qubits, name=name, s=s, **kwargs)

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -660,7 +660,7 @@ def LocalDephasingChannel(qubits: tuple[any, ...],
     p = _convert_to_dict(qubits, p)
 
     if pauli_index not in range(4):
-        raise ValueError("`")
+        raise ValueError("`pauli_index` must be in {0,1,2,3}")
 
     def s_p(pi):
         s = [1-pi, 0, 0, 0]

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -678,7 +678,7 @@ def _convert_to_dict(qubits, arg):
             arg = list(arg)
             if len(arg) != len(qubits):
                 raise ValueError("Must have exactly one value per qubit")
-            
+
             arg = {q: arg[i] for (i, q) in enumerate(qubits)}
         except TypeError:
             raise ValueError("Must be convertible to list")

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -357,9 +357,11 @@ def GlobalPauliChannel(qubits: tuple[any, ...],
     qubits: tuple[any, ...]
         Qubits the `LocalPauliChannel`s will act on.
     s: {float, array, dict}
-        Weight for Pauli matrices. The diagonal of `s` is set to `1`.
-        Similarly, if `s` is a one dimensional array, then the diagonal of `s`
-        is set to that array.  If `s` is a `dict`, weights can be specified by
+        Weight for Pauli matrices.
+        If `s` is a float, the diagonal of the matrix s_ij is set to `s`.
+        Similarly, if `s` is a one dimensional array, then the diagonal of
+        matrix s_ij is set to that array.
+        If `s` is a `dict`, weights can be specified by
         using the tokens `I`, `X`, `Y` and `Z`. For instance, `dict(XYYZ=0.2)`
         will set the weight for `sigma_i1 == X`, `sigma_i2 == Y`, `sigma_j1 == Y`
         and `sigma_j2 == Z` to `0.2`.

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -134,6 +134,10 @@ class _MatrixChannel(BaseChannel,
         return C
 
     def is_channel(self, atol=1e-8) -> bool:
+        """
+        Checks using the Choi matrix whether or not `self` defines
+        a valid quantum channel.
+        """
         C = self.choi_matrix()
         dim = int(np.sqrt(C.shape[0]))
 

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -112,6 +112,23 @@ class _MatrixChannel(BaseChannel,
         # Return Kraus operator
         return self.__Kraus
 
+    def choi_matrix(self) -> np.ndarray:
+        """
+        return the Choi matrix for channel of shape (d**2, d**2)
+        for a d-dimensional Hilbert space.
+        """
+        op = self.map()
+        # dimension (assume all have same shape)
+        d = self.Kraus.gates[0][0].matrix().shape[0]
+
+        C = np.zeros(d ** 4, dtype=complex).reshape(d ** 2, d ** 2)
+        for ij in range(d ** 2):
+            Eij = np.zeros(d ** 2)
+            Eij[ij] = 1
+            map = op @ Eij  # using vectorization
+            C += np.kron(Eij.reshape((d, d)), map.reshape((d, d)))
+        return C
+
     def map(self,
             order: tuple[any, ...] = None,
             *,

--- a/hybridq/noise/channel/channel.py
+++ b/hybridq/noise/channel/channel.py
@@ -504,7 +504,7 @@ def LocalDepolarizingChannel(qubits: tuple[any, ...],
     Parameters
     ----------
     qubits: tuple[any, ...]
-        Qubits the `LocalPauliChannel`s will act on.
+        Qubits the `LocalDepolarizingChannel`s will act on.
     p: {float, array, dict}
         Depolarizing probability for qubits.
         If a single value is passed, the same is used for all qubits.
@@ -544,7 +544,7 @@ def GlobalDepolarizingChannel(qubits: tuple[any, ...],
     Parameters
     ----------
     qubits: tuple[any, ...]
-        Qubits the `LocalPauliChannel`s will act on.
+        Qubits the `GlobalDepolarizingChannel` will act on.
     p: float
         Depolarizing probability.
     name: str, optional
@@ -576,7 +576,7 @@ def LocalDephasingChannel(qubits: tuple[any, ...],
     Parameters
     ----------
     qubits: tuple[any, ...]
-        Qubits the `LocalPauliChannel`s will act on.
+        Qubits the `LocalDephasingChannel`s will act on.
     p: {float, array, dict}
         Dephasing probability for qubits.
         If a single value is passed, the same is used for all qubits.
@@ -676,9 +676,13 @@ def _convert_to_dict(qubits, arg):
     else:
         try:
             arg = list(arg)
+            if len(arg) != len(qubits):
+                raise ValueError("Must have exactly one value per qubit")
+            
             arg = {q: arg[i] for (i, q) in enumerate(qubits)}
         except TypeError:
             raise ValueError("Must be convertible to list")
+
     if set(arg.keys()) != set(qubits):
         raise ValueError("Each qubit must be assigned")
     return arg

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -18,6 +18,9 @@ specific language governing permissions and limitations under the License.
 
 from __future__ import annotations
 import numpy as np
+from hybridq.circuit import Circuit
+from hybridq.noise.channel.channel import BaseChannel, GlobalDepolarizingChannel
+from hybridq.dm.circuit import Circuit as NoiseCircuit
 
 
 def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
@@ -40,6 +43,28 @@ def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
 
 def is_channel():
     raise NotImplementedError("working on this")
+
+
+def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):
+    """
+    Given a `Circuit`, add depolarizing noise after each instance of
+    a `BaseGate`, with the same locality as the gate.
+
+    Noise will not be added after a `BaseChannel`
+
+    probs: tuple[float, ...]
+        depolarizing probabilities as a tuple, where the k'th value corresponds
+        to the probability of depolarizing for a k-local gate.
+        probs should be the size of the largest locality `Gate` in the circuit.
+    """
+    c2 = NoiseCircuit()
+    for g in c:
+        c2 += [g]
+        if isinstance(c2, BaseChannel):
+            continue
+        c2 += [GlobalDepolarizingChannel(g.qubits, probs[len(g.qubits)-1])]
+    return c2
+
 
 
 

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -137,8 +137,8 @@ def ptrace(state: np.ndarray, keep: {int, list[int]},
         return np.einsum('ijkk->ij', state)
 
 
-def is_channel(channel: MatrixChannel, order: tuple[any, ...] = None,
-                atol=1e-8, **kwargs) -> bool:
+def is_channel(channel: MatrixChannel, atol=1e-8,
+               order: tuple[any, ...] = None, **kwargs) -> bool:
     """
     Checks using the Choi matrix whether or not `channel` defines
     a valid quantum channel.
@@ -146,11 +146,11 @@ def is_channel(channel: MatrixChannel, order: tuple[any, ...] = None,
 
     Parameters
     ----------
+    atol: float, optional
+        absolute tolerance to use for determining channel is CPTP.
     order: tuple[any, ...], optional
         If provided, Kraus' map is ordered accordingly to `order`.
         See `MatrixChannel.map()`
-    atol: float, optional
-        absolute tolerance to use for determining channel is CPTP.
     kwargs: kwargs for `MatrixChannel.map()`
     """
     C = choi_matrix(channel, order, **kwargs)

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -154,7 +154,7 @@ def is_channel(channel: MatrixChannel, order: tuple[any, ...] = None,
     kwargs: kwargs for `MatrixChannel.map()`
     """
     C = choi_matrix(channel, order, **kwargs)
-    dim = int(np.sqrt(C.shape[0]))
+    dim = _channel_dim(channel)
 
     # trace preserving
     tp = np.isclose(C.trace(), dim, atol=atol)
@@ -192,10 +192,9 @@ def choi_matrix(channel: MatrixChannel,
     """
 
     op = channel.map(order, **kwargs)
-    # dimension (assume all have same shape)
-    d = channel.Kraus.gates[0][0].matrix().shape[0]
+    d = _channel_dim(channel)
 
-    C = np.zeros(d ** 4, dtype=complex).reshape(d ** 2, d ** 2)
+    C = np.zeros((d**2, d**2), dtype=complex)
     for ij in range(d ** 2):
         Eij = np.zeros(d ** 2)
         Eij[ij] = 1
@@ -203,3 +202,8 @@ def choi_matrix(channel: MatrixChannel,
         C += np.kron(Eij.reshape((d, d)), map.reshape((d, d)))
 
     return C
+
+
+def _channel_dim(channel):
+    # dimension (assume all Kraus' have same shape)
+    return channel.Kraus.gates[0][0].matrix().shape[0]

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -1,0 +1,45 @@
+"""
+Authors: Salvatore Mandra (salvatore.mandra@nasa.gov),
+         Jeffrey Marshall (jeffrey.s.marshall@nasa.gov)
+
+Copyright © 2021, United States Government, as represented by the Administrator
+of the National Aeronautics and Space Administration. All rights reserved.
+
+The HybridQ: A Hybrid Simulator for Quantum Circuits platform is licensed under
+the Apache License, Version 2.0 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from __future__ import annotations
+import numpy as np
+
+
+def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
+    """
+    check if the given input a valid density matrix.
+    """
+    rho = np.asarray(rho)
+    d = int(np.sqrt(np.prod(rho.shape)))
+    rho_full = np.reshape(rho, (d, d))
+
+    hc = np.allclose(rho_full, rho_full.T.conj(), atol=atol)
+    tp = np.isclose(np.trace(rho_full), 1, atol=atol)
+
+    apprx_gtr = lambda y, x: np.real(y) >= x or np.isclose(y, x, atol=atol)
+    ev = np.linalg.eigvals(rho_full)
+    psd = np.all([apprx_gtr(e, 0) for e in ev])
+
+    return (hc and tp and psd)
+
+
+def is_channel():
+    raise NotImplementedError("working on this")
+
+
+

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -48,10 +48,12 @@ def is_channel():
 def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):
     """
     Given a `Circuit`, add depolarizing noise after each instance of
-    a `BaseGate`, with the same locality as the gate.
+    a `Gate`, with the same locality as the gate.
+    Note, noise will not be added after a `BaseChannel`
 
-    Noise will not be added after a `BaseChannel`
-
+    c: Circuit
+        The `Circuit` which will be modified. Note, a new `Circuit` is
+        returned (this is not in place).
     probs: tuple[float, ...]
         depolarizing probabilities as a tuple, where the k'th value corresponds
         to the probability of depolarizing for a k-local gate.

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -23,7 +23,6 @@ from hybridq.noise.channel.channel import BaseChannel, GlobalDepolarizingChannel
 from hybridq.dm.circuit import Circuit as SuperCircuit
 
 
-
 def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
     """
     check if the given input a valid density matrix.
@@ -40,10 +39,6 @@ def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
     psd = np.all([apprx_gtr(e, 0) for e in ev])
 
     return (hc and tp and psd)
-
-
-def is_channel():
-    raise NotImplementedError("working on this")
 
 
 def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -60,9 +60,13 @@ def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):
     c2 = NoiseCircuit()
     for g in c:
         c2 += [g]
-        if isinstance(c2, BaseChannel):
+        if isinstance(g, BaseChannel):
             continue
-        c2 += [GlobalDepolarizingChannel(g.qubits, probs[len(g.qubits)-1])]
+        k = len(g.qubits)  # locality
+        if k > len(probs):
+            raise ValueError("`probs` does not have sufficient "
+                             f"entries for {k}-local Gate")
+        c2 += [GlobalDepolarizingChannel(g.qubits, probs[k - 1])]
     return c2
 
 

--- a/hybridq/noise/utils.py
+++ b/hybridq/noise/utils.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import numpy as np
 from hybridq.circuit import Circuit
 from hybridq.noise.channel.channel import BaseChannel, GlobalDepolarizingChannel
-from hybridq.dm.circuit import Circuit as NoiseCircuit
+from hybridq.dm.circuit import Circuit as SuperCircuit
+
 
 
 def is_dm(rho: np.ndarray, atol=1e-6) -> bool:
@@ -59,7 +60,7 @@ def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):
         to the probability of depolarizing for a k-local gate.
         probs should be the size of the largest locality `Gate` in the circuit.
     """
-    c2 = NoiseCircuit()
+    c2 = SuperCircuit()
     for g in c:
         c2 += [g]
         if isinstance(g, BaseChannel):
@@ -72,8 +73,8 @@ def add_depolarizing_noise(c: Circuit, probs=(0., 0.)):
     return c2
 
 
-def ptrace(state: np.ndarray, keep: list[int],
-           dims: list[int] = None) -> np.ndarray:
+def ptrace(state: np.ndarray, keep: {int, list[int]},
+           dims: {int, list[int]}=None) -> np.ndarray:
     """
     compute the partial trace of a pure state (vector) or density matrix.
     state: np.array
@@ -84,8 +85,8 @@ def ptrace(state: np.ndarray, keep: list[int],
         Can also specify a single int if only keeping one qubit.
     dims: list of int, optional
         List of qudit dimensions respecting the ordering of `state`.
-        Number of qubits is len(dims), and full Hilbert space
-        dimension is product(dims).
+        Number of qubits is `len(dims)`, and full Hilbert space
+        dimension is `product(dims)`.
         If unspecified, assumes 2 for all.
     Returns the density matrix of the remaining qubits.
     """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -24,7 +24,7 @@ from hybridq.dm.circuit import simulation as dm_simulation
 from hybridq.noise.channel import GlobalDepolarizingChannel, \
     LocalDepolarizingChannel, LocalPauliChannel, AmplitudeDampingChannel, \
     LocalDephasingChannel
-from hybridq.noise.utils import ptrace, choi_matrix
+from hybridq.noise.utils import ptrace, choi_matrix, is_channel
 from hybridq.circuit import Circuit, simulation, utils
 from hybridq.circuit.simulation import clifford
 from hybridq.extras.io.cirq import to_cirq
@@ -2731,5 +2731,16 @@ def test_noise_1__choi(n):
     rho_t_choi = ptrace(np.kron(np.eye(d), rho.T) @ C, list(range(n)))
 
     np.testing.assert_array_almost_equal(rho_t, rho_t_choi)
+
+
+def test_noise_1__is_channel():
+    # check the first channel fails the test
+    ldc = LocalDephasingChannel((0,1), {0: 1.01, 1: 0.99})
+
+    invalid_channel = ldc[0]
+    valid_channel = ldc[1]
+
+    assert not is_channel(invalid_channel)
+    assert is_channel(valid_channel)
 
 #########################################################################

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2702,5 +2702,25 @@ def test_local_channels():
     np.testing.assert_array_almost_equal(rho1_tn, rho1_expected)
     np.testing.assert_array_almost_equal(rho2_tn, rho2_expected)
 
-    
+
+@pytest.mark.parametrize('n', [1, 2])
+def test_choi(n):
+    """
+    Choi matrix acts to produce the output state as
+    rho = Tr_0[ (I \otimes rho_0^T) C)
+    """
+    np.random.seed(1)
+    d = 2 ** n
+    psi = np.random.rand(d) + 1j * np.random.rand(d)
+    psi = psi / np.linalg.norm(psi)
+    rho = np.outer(psi, psi.conj())
+
+    g = GlobalDepolarizingChannel(list(range(n)), p=0.15)
+    rho_t = np.reshape(g.map() @ np.reshape(rho, (d ** 2, 1)), (d, d))
+
+    C = g.choi_matrix()
+    rho_t_choi = ptrace(np.kron(np.eye(d), rho.T) @ C, list(range(n)))
+
+    np.testing.assert_array_almost_equal(rho_t, rho_t_choi)
+
 #########################################################################

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2652,7 +2652,7 @@ def test_GlobalDepolarizingChannel(nq, p):
 
     expected = (1 - p) * rho + (p / d) * Id
 
-    gpc = GlobalDepolarizingChannel(list(range(nq)), p)
+    gpc = GlobalDepolarizingChannel(tuple(range(nq)), p)
     E = gpc.map()
     rho_v = np.reshape(rho, (d ** 2, 1))
     rho_t = np.reshape(E @ rho_v, (d, d))
@@ -2670,9 +2670,9 @@ def test_local_channels():
     q0, q1, q2 = 0, 1, 2
 
     c = SuperCircuit()
-    c += LocalPauliChannel([q0], s=[0.25, 0.0, 0, 0.75])
-    c += AmplitudeDampingChannel([q1], gamma=adc_gamma)
-    c += LocalDepolarizingChannel([q2], p=0.1)
+    c += LocalPauliChannel((q0,), s=[0.25, 0.0, 0, 0.75])
+    c += AmplitudeDampingChannel((q1,), gamma=adc_gamma)
+    c += LocalDepolarizingChannel((q2,), p=0.1)
 
     rho = np.reshape(
         dm_simulation.simulate(c, '+', optimize='evolution-einsum'), (d, d))
@@ -2715,10 +2715,11 @@ def test_choi(n):
     psi = psi / np.linalg.norm(psi)
     rho = np.outer(psi, psi.conj())
 
-    g = GlobalDepolarizingChannel(list(range(n)), p=0.15)
+    g = GlobalDepolarizingChannel(tuple(range(n)), p=0.15)
     rho_t = np.reshape(g.map() @ np.reshape(rho, (d ** 2, 1)), (d, d))
 
     C = g.choi_matrix()
+    # trace out first n qubits representing the identity part
     rho_t_choi = ptrace(np.kron(np.eye(d), rho.T) @ C, list(range(n)))
 
     np.testing.assert_array_almost_equal(rho_t, rho_t_choi)


### PR DESCRIPTION
Here I made a few changes to `hybridq.noise` from the `add-noise-gates` branch, in particular

- Additional functionality in the `MatrixChannel` class, such as a method to check if it defines a valid channel, and to get the Choi matrix.
- Some density matrix utilities such as checking a valid density matrix and for computing the partial trace. Also a function to add depolarizing noise to a `Circuit`.
- Some custom noise channels: `AmplitudeDampingChannel`, `GlobalDepolarizingChannel`,  `LocalDepolarizingChannel`
- A few tests.