### PR TITLE
Fix `__Base__.__eq__`

### DIFF
--- a/hybridq/base/base.py
+++ b/hybridq/base/base.py
@@ -495,7 +495,7 @@ class __Base__:
 
         # Perform all checks
         return all(
-            cmp(getattr(self, k), getattr(other, k))
+            np.all(cmp(getattr(self, k), getattr(other, k)))
             for c in compare
             for k, cmp in c.items())
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class MyInstall(DistutilsInstall):
 here = path.abspath(path.dirname(__file__))
 
 # Version
-version = '0.7.7-4'
+version = '0.7.7-5'
 
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
At the moment, if `A` compares variables not in `B`, an `AttributeError` is raised. With the fix, `False` is returned instead. Also, this patch fix some commutation issues that would lead `A == B` being different than `B == A`.