### PR TITLE
Circuit: Add `__iadd__`

### DIFF
--- a/hybridq/circuit/circuit.py
+++ b/hybridq/circuit/circuit.py
@@ -110,11 +110,17 @@ class BaseCircuit(list):
 
     def __add__(self, circuit: Circuit) -> Circuit:
         """
-        Add `Circuit` to an existing `Circuit`, and return a new `Circuit`.
+        Add `circuit` to an existing `Circuit`, and return a new `Circuit`.
         """
 
         # Return new circuit
         return type(self)(list(self) + list(type(self)(circuit)))
+
+    def __iadd__(self, circuit: Circuit) -> None:
+        """
+        Append `circuit` to an existing `Circuit`.
+        """
+        self.extend(circuit)
 
     def __getitem__(self, key: any) -> {Gate, Circuit}:
         """

--- a/hybridq/circuit/circuit.py
+++ b/hybridq/circuit/circuit.py
@@ -120,7 +120,11 @@ class BaseCircuit(list):
         """
         Append `circuit` to an existing `Circuit`.
         """
+        # Extend circuit
         self.extend(circuit)
+
+        # Return
+        return self
 
     def __getitem__(self, key: any) -> {Gate, Circuit}:
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1099,21 +1099,59 @@ def test_circuit__operations(n_qubits, n_gates):
     # Generate initial random circuit
     _c = _get_rqc_non_unitary(n_qubits=n_qubits, n_gates=n_gates)
 
+    # Try valid gates
+    try:
+        Circuit([1])
+        raise
+    except:
+        pass
+
     # Initialize circuit
     c = Circuit(_c)
+
+    # Add circuit
+    c = c + c
+
+    # Try valid gates
+    try:
+        c = c + [1]
+        raise
+    except:
+        pass
 
     # Append gates one by one
     for g in _c:
         c.append(g)
 
+    # Try valid gates
+    try:
+        c.append(1)
+        raise
+    except:
+        pass
+
     # Extend circuit
     c.extend(_c)
+
+    # Try valid gates
+    try:
+        c.extend([1])
+        raise
+    except:
+        pass
 
     # Use += operator
     c += _c
 
+    # Try valid gates
+    try:
+        c += [1]
+        raise
+    except:
+        pass
+
     # Check
-    assert (c == Circuit(_c + _c + _c + _c))
+    assert (c == Circuit(_c + _c + _c + _c + _c))
 
 
 @pytest.mark.parametrize('n_qubits,n_gates', [(8, 200) for _ in range(5)])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1094,6 +1094,28 @@ def test_gate_utils__decompose_gate(n_qubits, k):
 ################################ TEST CIRCUIT ################################
 
 
+@pytest.mark.parametrize('n_qubits,n_gates', [(50, 200) for _ in range(5)])
+def test_circuit__operations(n_qubits, n_gates):
+    # Generate initial random circuit
+    _c = _get_rqc_non_unitary(n_qubits=n_qubits, n_gates=n_gates)
+
+    # Initialize circuit
+    c = Circuit(_c)
+
+    # Append gates one by one
+    for g in _c:
+        c.append(g)
+
+    # Extend circuit
+    c.extend(_c)
+
+    # Use += operator
+    c += _c
+
+    # Check
+    assert (c == Circuit(_c + _c + _c + _c))
+
+
 @pytest.mark.parametrize('n_qubits,n_gates', [(8, 200) for _ in range(5)])
 def test_circuit__conj_T_adj_inv(n_qubits, n_gates):
     # Get random circuit


### PR DESCRIPTION
At the moment, it would be possible to add to `circuit`s arbitrary objects by using:
```
c = Circuit()
c += [1]
```
To fix the problem, `__iadd__` has been added.
